### PR TITLE
Update copyright holders re: CSIRO contract

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,7 @@ SS-Atlantis Analysis
 *********************************************
 :License: Apache License, Version 2.0
 
-This is a collection of analyses by Raisha Lovindeer
-.
+This is a collection of analyses by Raisha Lovindeer.
 Most of the files are Jupyter Notebooks.
 Please see the ``README.md`` files in each directory for links to read-only renderings of the notebooks.
 
@@ -12,11 +11,10 @@ Please see the ``README.md`` files in each directory for links to read-only rend
 License
 =======
 
-These analyses and documentation are copyright by the `UBC EOAS MOAD Group`_
-and The University of British Columbia.
+These analyses and documentation are copyright by the Salish Sea Atlantis project contributors,
+The University of British Columbia,
+and CSIRO.
 
 They are licensed under the Apache License, Version 2.0.
 http://www.apache.org/licenses/LICENSE-2.0
 Please see the LICENSE file for details of the license.
-
-.. _UBC EOAS MOAD Group: https://github.com/UBC-MOAD/docs/blob/main/CONTRIBUTORS.rst

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -19,8 +19,9 @@ Descriptions below the links are from the first cell of the notebooks
 ## License
 
 These notebooks and files are copyright by the
-[UBC EOAS MOAD Group](https://github.com/UBC-MOAD/docs/blob/main/CONTRIBUTORS.rst)
-and The University of British Columbia.
+Salish Sea Atlantis project contributors,
+The University of British Columbia,
+and CSIRO.
 
 They are licensed under the Apache License, Version 2.0.
 http://www.apache.org/licenses/LICENSE-2.0

--- a/notebooks/make_readme.py
+++ b/notebooks/make_readme.py
@@ -1,4 +1,5 @@
-# Copyright by the UBC EOAS MOAD Group and The University of British Columbia.
+# Copyright by the Salish Sea Atlantis project contributors,
+# The University of British Columbia, and CSIRO.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,9 +57,8 @@ Descriptions below the links are from the first cell of the notebooks
     license = f"""
 ## License
 
-These notebooks and files are copyright by the
-[UBC EOAS MOAD Group](https://github.com/UBC-MOAD/docs/blob/main/CONTRIBUTORS.rst)
-and The University of British Columbia.
+These notebooks and files are copyright by the Salish Sea Atlantis project contributors,
+The University of British Columbia, and CSIRO.
 
 They are licensed under the Apache License, Version 2.0.
 http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
When I was setting up the AtlantisCmd repo I reviewed the IP elements of the UBC-CSIRO contract for this project and concluded (in consultation with Susan) that the appropriate copyright holders words for code and docs we create in the project are "Salish Sea Atlantis project contributors, The University of British Columbia, and CSIRO". 

So, this PR does that update for you because I should have figured that all out and put it in the cookiecutter before we created this repo. You can merge this at your leisure - no hurry. If you haven't worked with PRs and want a quick run-down on the workflow and the merge options (Merge, Squash & Merge, ...), I'm happy to do that.